### PR TITLE
#3 Use dropzoneMessageClassName to register clickable event

### DIFF
--- a/src/hooks/config.js
+++ b/src/hooks/config.js
@@ -25,6 +25,7 @@ export default function useConfig({ props, context, setMultiple }) {
     chunking: props.chunking,
     numberOfChunks: props.numberOfChunks,
     multipleUpload: props.chunking ? false : props.multipleUpload,
+    dropzoneMessageClassName: props.dropzoneMessageClassName,
     accepts: [],
   });
   const createAcceptsArray = () => {

--- a/src/hooks/hiddenIpuntFile.js
+++ b/src/hooks/hiddenIpuntFile.js
@@ -72,7 +72,7 @@ export default function useHiddenInputFile() {
     config, dropzone, itemManager,
   }) => {
     if (config.clickable) {
-      const element = getElement('.dropzone__message', 'dropzone__message');
+      const element = getElement(`.${config.dropzoneMessageClassName}`, config.dropzoneMessageClassName);
       const elements = getAllDescendants(element);
       clickableElements = [dropzone.value];
       clickableElements.push(element);


### PR DESCRIPTION
There is an issue with using multiple DropZone elements at the same time which appears to be because the clickable event is registered to `.dropzone__message`, regardless of the value passed for the `dropzoneMessageClassName` property. As the class is not unique when the subsequent elements are rendered, it is re-registered on the same previous element causing multiple file windows to popup.

This change adds the `dropzoneMessageClassName` to the configuration object and using the value to register the clickable event in the hiddenInputFile hook. Therefore, when multiple dropzones are used, each element can uniquely have a clickable event registered.

Feel free to suggest changes where needed, this worked for me.